### PR TITLE
Update add-bano-addresses.sh; add scriptdir, correct some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The prerequisites are GNU awk, [osmconvert](http://wiki.openstreetmap.org/wiki/O
 You'll have to edit the script to configure it to your installation : 
 - BANODIR=directory where the script will download and store the BANO files
 - PBFDIR=directory where the .pbf files are read and written. The read file must follow the Geofabrik naming convention _region_-latest.osm.pbf.
-- BINDIR=directory where osmconvert is stored
+- BINDIR=directory where osmconvert and osmfilter are stored. you can use the versions from your distribution but they are sometimes old.
 - SCRIPTDIR=directory where the scripts reside (as you don't want your data mingled with your code)
 Please use full datapaths, not relative datapaths
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# bano2garmin
-Shell script that adds BANO addresses (France only) to OpenStreetMap files before generating Garmin maps
+# bano2OsmAnd
+
+This is forked from bano2garmin from PacoTyson at https://github.com/PacoTyson/bano2garmin.
+All credits for the oroginal scripts go to Paco.
+
+Shell script that adds BANO addresses (France only) to OpenStreetMap .osm/.o5m/.osm.pbf files before generating OsmAnd maps
 The prerequisites are GNU awk and [osmconvert](http://wiki.openstreetmap.org/wiki/Osmconvert)
 
 You'll have to edit the script to configure it to your installation : 
 - BANODIR=directory where the script will download and store the BANO files
 - PBFDIR=directory where the .pbf files are read and written. The read file must follow the Geofabrik naming convention _region_-latest.osm.pbf.
 - BINDIR=directory where osmconvert is stored
+- SCRIPTDIR=directory where the scripts reside (as you don't want your data mingled with your code)
+Please use full datapaths, not relative datapaths
 
 
 
@@ -14,4 +20,5 @@ where _region_ can be france or any of those listed on http://download.geofabrik
 
 
  
-It has been tested on Debian Jessie and OS X 10.9.
+The original script has been tested on Debian Jessie and OS X 10.9.
+My scripts have been tested on Debian Jessie and Ubuntu 15.10.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # bano2OsmAnd
 
 This is forked from bano2garmin from PacoTyson at https://github.com/PacoTyson/bano2garmin.
-All credits for the oroginal scripts go to Paco.
+All credits for the original scripts go to Paco.
 
-Shell script that adds BANO addresses (France only) to OpenStreetMap .osm/.o5m/.osm.pbf files before generating OsmAnd maps
-The prerequisites are GNU awk and [osmconvert](http://wiki.openstreetmap.org/wiki/Osmconvert)
+Shell script that adds BANO addresses (France only) to OpenStreetMap .osm/.o5m/.osm.pbf files before generating OsmAnd maps.<BR>
+The prerequisites are GNU awk, [osmconvert](http://wiki.openstreetmap.org/wiki/Osmconvert), [osmfilter](http://wiki.openstreetmap.org/wiki/Osmfilter)
 
 You'll have to edit the script to configure it to your installation : 
 - BANODIR=directory where the script will download and store the BANO files

--- a/add-bano-addresses.sh
+++ b/add-bano-addresses.sh
@@ -2,9 +2,12 @@
 
 set -eu
 
+# The options are mentioned here as relative paths but please use full absolute paths
+# like /home/<username/BANO-FRANCE/BANODIR
 BANODIR=.
 PBFDIR=..
 BINDIR=.
+SCRIPTDIR=.
 
 UPDATE=0
 PROCESS=0
@@ -52,7 +55,7 @@ then
 fi
 
 
-DEPTS=$(grep $MAP BANO-mapping-region-departements.txt | cut -f 2 | sed s/,/\ /g)
+DEPTS=$(grep $MAP "$SCRIPTDIR"/BANO-region-departements-mapping.txt | cut -f 2 | sed s/,/\ /g)
 
 if [ $UPDATE -eq 1 ];
 then
@@ -71,14 +74,14 @@ fi
 if [ $PROCESS -eq 1 ];
 then
     echo "Processing..."
-    echo > bano-$MAP.csv
+    echo > "$BANODIR"/bano-$MAP.csv
     for i in $DEPTS
     do
-        cat "$BANODIR"/bano-"$i".csv >> bano-$MAP.csv
+        cat "$BANODIR"/bano-"$i".csv >> "$BANODIR"/bano-$MAP.csv
     done
 
-    awk -f bano2osm.awk bano-$MAP.csv > bano-$MAP.osm
+    awk -f "$SCRIPTDIR"/bano2osm.awk "$BANODIR"/bano-$MAP.csv > "$BANODIR"/bano-$MAP.osm
 
-    $BINDIR/osmconvert $PBFDIR/$MAP-latest.osm.pbf bano-$MAP.osm --out-pbf > $PBFDIR/$MAP-latest-with-bano.osm.pbf
+    $BINDIR/osmconvert $PBFDIR/$MAP-latest.osm.pbf "$BANODIR"/bano-$MAP.osm --out-pbf > $PBFDIR/$MAP-latest-with-bano.osm.pbf
 fi
 

--- a/add-bano-addresses.sh
+++ b/add-bano-addresses.sh
@@ -82,7 +82,8 @@ then
 
     echo On low memory  machines use the --hash-memory=400-50-2 option
     # Below line is the original with the full france map
-    $BINDIR/osmconvert -v --hash-memory=400-50-2 $PBFDIR/$MAP-latest.osm.pbf "$BANODIR"/bano-$MAP.osm --out-pbf > $PBFDIR/$MAP-latest-with-bano.osm.pbf
+    #$BINDIR/osmconvert -v --hash-memory=400-50-2 $PBFDIR/$MAP-latest.osm.pbf "$BANODIR"/bano-$MAP.osm --out-pbf > $PBFDIR/$MAP-latest-with-bano.osm.pbf
+    
     # lines below first convert the full france map to a address only map and then merges it with the bano map
     $BINDIR/osmconvert -v --drop-version --hash-memory=400-50-2 $PBFDIR/$MAP-latest.osm.pbf --out-o5m > $PBFDIR/$MAP-latest.o5m
     # Now create an osm file only containing addresses (and some garbage left)

--- a/add-bano-addresses.sh
+++ b/add-bano-addresses.sh
@@ -87,7 +87,7 @@ then
     # lines below first convert the full france map to a address only map and then merges it with the bano map
     $BINDIR/osmconvert -v --drop-version --hash-memory=400-50-2 $PBFDIR/$MAP-latest.osm.pbf --out-o5m > $PBFDIR/$MAP-latest.o5m
     # Now create an osm file only containing addresses (and some garbage left)
-    #$BINDIR/osmfilter  --drop-version --parameter-file="$SCRIPTDIR"/address_only.txt --hash-memory=400-50-2 $PBFDIR/$MAP-latest.o5m -o=$PBFDIR/$MAP-latest-address.o5m
+    $BINDIR/osmfilter  --drop-version --parameter-file="$SCRIPTDIR"/address_only.txt --hash-memory=400-50-2 $PBFDIR/$MAP-latest.o5m -o=$PBFDIR/$MAP-latest-address.o5m
     # Now create an osm file containing the admin boundaries necessary for OsmAnd to create an address map
     $BINDIR/osmfilter --drop-version $PBFDIR/$MAP-latest.o5m --hash-memory=400-50-2 --keep="boundary=administrative" --out-o5m -o=$PBFDIR/$MAP-latest-boundaries.o5m
     # Now create the combined address map

--- a/add-bano-addresses.sh.original_improved
+++ b/add-bano-addresses.sh.original_improved
@@ -2,10 +2,12 @@
 
 set -eu
 
-BANODIR=/opt/OpenStreetMap/Bano-Address-France/BANODIR
-PBFDIR=/opt/OpenStreetMap/Bano-Address-France/PBFDIR
-BINDIR=/opt/software/OsmAnd-UKpostcodes/tools
-SCRIPTDIR=/opt/OpenStreetMap/Bano-Address-France/bano2garmin
+# The options are mentioned here as relative paths but please use full absolute paths
+# like /home/<username/BANO-FRANCE/BANODIR
+BANODIR=.
+PBFDIR=..
+BINDIR=.
+SCRIPTDIR=.
 
 UPDATE=0
 PROCESS=0
@@ -80,17 +82,6 @@ then
 
     awk -f "$SCRIPTDIR"/bano2osm.awk "$BANODIR"/bano-$MAP.csv > "$BANODIR"/bano-$MAP.osm
 
-    echo On low memory  machines use the --hash-memory=400-50-2 option
-    # Below line is the original with the full france map
-    $BINDIR/osmconvert -v --hash-memory=400-50-2 $PBFDIR/$MAP-latest.osm.pbf "$BANODIR"/bano-$MAP.osm --out-pbf > $PBFDIR/$MAP-latest-with-bano.osm.pbf
-    # lines below first convert the full france map to a address only map and then merges it with the bano map
-    $BINDIR/osmconvert -v --drop-version --hash-memory=400-50-2 $PBFDIR/$MAP-latest.osm.pbf --out-o5m > $PBFDIR/$MAP-latest.o5m
-    # Now create an osm file only containing addresses (and some garbage left)
-    #$BINDIR/osmfilter  --drop-version --parameter-file="$SCRIPTDIR"/address_only.txt --hash-memory=400-50-2 $PBFDIR/$MAP-latest.o5m -o=$PBFDIR/$MAP-latest-address.o5m
-    # Now create an osm file containing the admin boundaries necessary for OsmAnd to create an address map
-    $BINDIR/osmfilter --drop-version $PBFDIR/$MAP-latest.o5m --hash-memory=400-50-2 --keep="boundary=administrative" --out-o5m -o=$PBFDIR/$MAP-latest-boundaries.o5m
-    # Now create the combined address map
-    $BINDIR/osmconvert -v --hash-memory=400-50-2 $PBFDIR/$MAP-latest-boundaries.o5m $PBFDIR/$MAP-latest-address.o5m "$BANODIR"/bano-$MAP.osm --out-pbf > $PBFDIR/$MAP-latest-with-bano.osm.pbf
-
+    $BINDIR/osmconvert $PBFDIR/$MAP-latest.osm.pbf "$BANODIR"/bano-$MAP.osm --out-pbf > $PBFDIR/$MAP-latest-with-bano.osm.pbf
 fi
 

--- a/address_only.txt
+++ b/address_only.txt
@@ -1,0 +1,14 @@
+-v
+
+--keep=
+addr:*
+
+--drop-ways=*
+
+--drop-relations=* 
+
+--drop-tags=*
+
+--keep-nodes=
+
+--out-o5m


### PR DESCRIPTION
- The BANO-region-departements-mapping.txt was incorrect in the script
- Added a SCRIPTDIR because you want to keep your scripts (or github folder) separate from your data
- Add remark about full paths instead of relative paths because when you use several folders the (original) script does not work correctly
